### PR TITLE
Added quotation to configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Available configuration options:
 ```cson
 "atom-randomstring":
   length: 64
-  charset: alphanumeric
+  charset: "alphanumeric"
 ```
 
 These options are [passed onto randomstring]([randomstring](https://github.com/klughammer/node-randomstring), so check there for more documentation.


### PR DESCRIPTION
Strings need quotation in Atom's config file
